### PR TITLE
Reset Context, even when exceptions are thrown

### DIFF
--- a/src/contextuallogging/_context.py
+++ b/src/contextuallogging/_context.py
@@ -84,8 +84,13 @@ def context(
                 key=keyword if key is None else key,
                 value=kwargs[keyword],
             )
-            result: Final[Any] = await function(*args, **kwargs)
-            reset_context(token=token)
+            try:
+                result: Final[Any] = await function(*args, **kwargs)
+            except:
+                raise
+            # Finally is run before the re-raise happens.
+            finally:
+                reset_context(token=token)
             return result
 
     else:
@@ -99,8 +104,13 @@ def context(
                 key=keyword if key is None else key,
                 value=kwargs[keyword],
             )
-            result: Final[Any] = function(*args, **kwargs)
-            reset_context(token=token)
+            try:
+                result: Final[Any] = function(*args, **kwargs)
+            except:
+                raise
+            # Finally is run before the re-raise happens.
+            finally:
+                reset_context(token=token)
             return result
 
     return wrapper

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -44,10 +44,33 @@ def test_context(
     async def async_function(**kwargs: Any) -> None:  # noqa: ARG001, ANN401
         assert_that(get_context()).is_equal_to(expected)
 
+    @context(keyword=keyword, key=key)
+    def function_with_error(**kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        assert_that(get_context()).is_equal_to(expected)
+        raise ValueError
+
+    @context(keyword=keyword, key=key)
+    async def async_function_with_error(**kwargs: Any) -> None:  # noqa: ARG001, ANN401
+        assert_that(get_context()).is_equal_to(expected)
+        raise ValueError
+
     assert_that(get_context()).is_equal_to({})
     function(**arguments)
     assert_that(get_context()).is_equal_to({})
     asyncio.get_event_loop().run_until_complete(async_function(**arguments))
+    assert_that(get_context()).is_equal_to({})
+
+    # Tests where the decorated function throw errors
+    assert_that(get_context()).is_equal_to({})
+    try:
+        function_with_error(**arguments)
+    except ValueError:
+        pass
+    assert_that(get_context()).is_equal_to({})
+    try:
+        asyncio.get_event_loop().run_until_complete(async_function_with_error(**arguments))
+    except ValueError:
+        pass
     assert_that(get_context()).is_equal_to({})
 
 


### PR DESCRIPTION
Currently, when an exception is thrown in code under the `@context` decorator, the context is not reset. This can cause issues in long-running systems where errors are expected, caught, and handled. In the included example, registering a batch of users can have one registration fail but the others should continue.

```python
import sys
import logging
from contextuallogging import context, ContextualFormatter

logger = logging.getLogger()
handler = logging.StreamHandler(sys.stdout)
handler.setFormatter(ContextualFormatter())
logger.addHandler(handler)
logger.setLevel(logging.INFO)


@context(keyword="username", key="user")
def register_user(username: str):
    if username == "Bill":
        logger.error("Banned User")
        raise ValueError("Bill is banned")
    logger.info("Registering User")


@context(keyword="file")
def register_users(file: str):
    # Read a file in a real version
    logger.info("Reading File")
    users = ["Jeff", "Bill", "Joan"]
    for user in users:
        try:
          register_user(username=user)
        except ValueError:
          continue
    logger.info("Finished Registering Users")


if __name__ == "__main__":
    register_users(file="users.txt")
```

In the current implementation, the context of `user=Bill` persists past the registration of users and shows up in other log messages.

```json
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Reading File",
  "timestamp": "2024-08-29T15:45:30.844681Z"
}
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Registering User",
  "timestamp": "2024-08-29T15:45:30.844766Z",
  "user": "Jeff"
}
{
  "file": "users.txt",
  "level": "ERROR",
  "logger": "root",
  "message": "Banned User",
  "timestamp": "2024-08-29T15:45:30.844811Z",
  "user": "Bill"
}
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Registering User",
  "timestamp": "2024-08-29T15:45:30.844882Z",
  "user": "Joan"
}
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Finished Registering Users",
  "timestamp": "2024-08-29T15:45:30.844953Z",
  "user": "Bill"
}
```

This PR ensure the context is reset, even when an error occurs. In the new log output, we see that `user=Bill` is now gone from the last log message.

```json
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Reading File",
  "timestamp": "2024-08-29T15:45:00.965263Z"
}
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Registering User",
  "timestamp": "2024-08-29T15:45:00.965363Z",
  "user": "Jeff"
}
{
  "file": "users.txt",
  "level": "ERROR",
  "logger": "root",
  "message": "Banned User",
  "timestamp": "2024-08-29T15:45:00.965407Z",
  "user": "Bill"
}
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Registering User",
  "timestamp": "2024-08-29T15:45:00.965444Z",
  "user": "Joan"
}
{
  "file": "users.txt",
  "level": "INFO",
  "logger": "root",
  "message": "Finished Registering Users",
  "timestamp": "2024-08-29T15:45:00.965478Z"
}
```